### PR TITLE
added ability to override build scripts used

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,18 @@ This allows references and attributes from resources such as an API endpoint, fo
   }
 </script>
 ```
+## Configuration
+If you're using a custom script to build the project you can supply the build parameters in the custom settings of serverless.yml. For example, if you're using Typescript with react-app-rewired and the build script in package.json is `"react-app-rewired build --scripts-version react-scripts-ts"` you can configure the plugin to use this command like this:
 
+```yaml
+# serverless.yml
+custom:
+  build-create-react-app:
+    command: react-app-rewired
+    params:
+      - --scripts-version
+      - react-scripts-ts
+```
 ## Hooks
 
 * On running `serverless deploy`, Create React App will spawn the build process and generate a static site in the `build` directory

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class BuildReactForSyncPlugin {
     return this.getStackOutputs().then(outputs => {
       const command = [];
       const env = { ...process.env, ...outputs };
-      const buildopts = this.serverless.service.custom['build-cra'];
+      const buildopts = this.serverless.service.custom['build-create-react-app'];
 
       if (buildopts) {
         command.push(require.resolve(buildopts.command + '/scripts/build'));

--- a/index.js
+++ b/index.js
@@ -33,9 +33,18 @@ class BuildReactForSyncPlugin {
 
   buildReactApp() {
     return this.getStackOutputs().then(outputs => {
+      const command = [];
       const env = { ...process.env, ...outputs };
-      const build = require.resolve('react-scripts/scripts/build');
-      const result = spawn.sync( 'node', [build], { stdio: 'inherit', env });
+      const buildopts = this.serverless.service.custom['build-cra'];
+
+      if (buildopts) {
+        command.push(require.resolve(buildopts.command + '/scripts/build'));
+        command.push(...buildopts.params);
+      } else {
+        command.push(require.resolve('react-scripts/scripts/build'));
+      }
+
+      const result = spawn.sync('node', command, {stdio: 'inherit', env});
       return Promise.resolve(result.status);
     });
   }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ class BuildReactForSyncPlugin {
 
       if (buildopts) {
         command.push(require.resolve(buildopts.command + '/scripts/build'));
-        command.push(...buildopts.params);
+        if (buildopts.params) {
+          command.push(...buildopts.params);
+        }
       } else {
         command.push(require.resolve('react-scripts/scripts/build'));
       }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ class BuildReactForSyncPlugin {
     return this.getStackOutputs().then(outputs => {
       const command = [];
       const env = { ...process.env, ...outputs };
-      const buildopts = this.serverless.service.custom['build-create-react-app'];
+      const buildopts =
+        this.serverless.service.custom &&
+        this.serverless.service.custom['build-create-react-app'];
 
       if (buildopts) {
         command.push(require.resolve(buildopts.command + '/scripts/build'));


### PR DESCRIPTION
I use the typescript build scripts with CRA along with react-app-rewired to make some overrides without ejecting. This allows adding a custom variable to serverless.yml and build with those configs. Not fully tested. Feel free to change or ignore.

```
# serverless.yml
custom:
  build-cra:
    command: react-app-rewired
    params:
      - --scripts-version
      - react-scripts-ts
```